### PR TITLE
feat(frontend): add nesting upload form components

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,35 +1,13 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import './App.css';
+import NestingForm from './components/NestingForm';
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <div>
+      <h1>Nesting App</h1>
+      <NestingForm />
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface FileUploaderProps {
+  onFilesSelected: (files: FileList) => void;
+}
+
+/**
+ * Simple input for selecting SVG or DXF files.
+ */
+const FileUploader: React.FC<FileUploaderProps> = ({ onFilesSelected }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      onFilesSelected(e.target.files);
+    }
+  };
+
+  return (
+    <div>
+      <input
+        type="file"
+        accept=".svg,.dxf"
+        multiple
+        onChange={handleChange}
+      />
+    </div>
+  );
+};
+
+export default FileUploader;

--- a/frontend/src/components/NestingForm.tsx
+++ b/frontend/src/components/NestingForm.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import FileUploader from './FileUploader';
+import NestingParametersForm, { NestingParameters } from './NestingParameters';
+import api from '../services/api';
+
+/**
+ * Combines file uploading and parameter inputs, posts to the backend
+ * and shows the returned placements.
+ */
+const NestingForm: React.FC = () => {
+  const [files, setFiles] = useState<FileList | null>(null);
+  const [params, setParams] = useState<NestingParameters>({ spacing: 0, allowRotation: true });
+  const [placements, setPlacements] = useState<unknown>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!files || files.length === 0) {
+      setError('Please select at least one file.');
+      return;
+    }
+
+    const formData = new FormData();
+    Array.from(files).forEach((file) => formData.append('files', file));
+    formData.append('spacing', String(params.spacing));
+    formData.append('allowRotation', String(params.allowRotation));
+
+    try {
+      setLoading(true);
+      const response = await api.post('/nest', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+      setPlacements(response.data);
+      setError(null);
+    } catch {
+      setError('Nesting failed');
+      setPlacements(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <FileUploader onFilesSelected={setFiles} />
+      <NestingParametersForm onChange={setParams} />
+      <button onClick={handleSubmit} disabled={loading}>
+        {loading ? 'Nesting...' : 'Nest'}
+      </button>
+      {error && <div className="error">{error}</div>}
+      {placements && (
+        <pre>{JSON.stringify(placements, null, 2)}</pre>
+      )}
+    </div>
+  );
+};
+
+export default NestingForm;

--- a/frontend/src/components/NestingParameters.tsx
+++ b/frontend/src/components/NestingParameters.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+export interface NestingParameters {
+  spacing: number;
+  allowRotation: boolean;
+}
+
+interface NestingParametersProps {
+  onChange: (params: NestingParameters) => void;
+}
+
+/**
+ * Form inputs for basic nesting parameters.
+ */
+const NestingParametersForm: React.FC<NestingParametersProps> = ({ onChange }) => {
+  const [spacing, setSpacing] = useState(0);
+  const [allowRotation, setAllowRotation] = useState(true);
+
+  const updateSpacing = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseFloat(e.target.value);
+    setSpacing(value);
+    onChange({ spacing: value, allowRotation });
+  };
+
+  const updateRotation = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const checked = e.target.checked;
+    setAllowRotation(checked);
+    onChange({ spacing, allowRotation: checked });
+  };
+
+  return (
+    <div>
+      <label>
+        Spacing:
+        <input type="number" value={spacing} onChange={updateSpacing} />
+      </label>
+      <label>
+        Allow Rotation:
+        <input type="checkbox" checked={allowRotation} onChange={updateRotation} />
+      </label>
+    </div>
+  );
+};
+
+export default NestingParametersForm;


### PR DESCRIPTION
## Summary
- add FileUploader and NestingParameters components
- post SVG/DXF files and parameters to `/api/nest` and show placements
- wire new NestingForm into App

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68962855eb7c83308ec7e1e0465541b0