### PR TITLE
Add preview and export controls to frontend

### DIFF
--- a/frontend/src/components/NestingForm.tsx
+++ b/frontend/src/components/NestingForm.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import FileUploader from './FileUploader';
 import NestingParametersForm, { NestingParameters } from './NestingParameters';
 import api from '../services/api';
+import NestingPreview, { NestingResult } from '../views/NestingPreview';
 
 /**
  * Combines file uploading and parameter inputs, posts to the backend
@@ -10,7 +11,7 @@ import api from '../services/api';
 const NestingForm: React.FC = () => {
   const [files, setFiles] = useState<FileList | null>(null);
   const [params, setParams] = useState<NestingParameters>({ spacing: 0, allowRotation: true });
-  const [placements, setPlacements] = useState<unknown>(null);
+  const [layout, setLayout] = useState<NestingResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -22,21 +23,47 @@ const NestingForm: React.FC = () => {
 
     const formData = new FormData();
     Array.from(files).forEach((file) => formData.append('files', file));
-    formData.append('spacing', String(params.spacing));
-    formData.append('allowRotation', String(params.allowRotation));
+    // Backend expects a JSON "config" payload. Provide basic defaults for
+    // fields not yet exposed in the UI.
+    const config = {
+      spacing: params.spacing,
+      rotationStep: params.allowRotation ? 90 : 0,
+      sheetWidth: 100,
+      sheetHeight: 100,
+      maxNoImprovement: 10,
+    };
+    formData.append('config', JSON.stringify(config));
 
     try {
       setLoading(true);
-      const response = await api.post('/nest', formData, {
+      const response = await api.post<NestingResult>('/nest', formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
-      setPlacements(response.data);
+      setLayout(response.data);
       setError(null);
     } catch {
       setError('Nesting failed');
-      setPlacements(null);
+      setLayout(null);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleExport = async () => {
+    if (!layout) return;
+    try {
+      const response = await api.post('/export', { format: 'svg', layout }, {
+        responseType: 'blob',
+      });
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', 'nested_layout.svg');
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch {
+      setError('Export failed');
     }
   };
 
@@ -48,8 +75,11 @@ const NestingForm: React.FC = () => {
         {loading ? 'Nesting...' : 'Nest'}
       </button>
       {error && <div className="error">{error}</div>}
-      {placements && (
-        <pre>{JSON.stringify(placements, null, 2)}</pre>
+      {layout && (
+        <div>
+          <NestingPreview layout={layout} />
+          <button onClick={handleExport}>Export</button>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/views/NestingPreview.tsx
+++ b/frontend/src/views/NestingPreview.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+/** Placement returned from the nesting backend. */
+export interface Placement {
+  id: string;
+  x: number;
+  y: number;
+  rotation: number;
+}
+
+/** Specification of the sheet used for nesting. */
+export interface SheetSpec {
+  width: number;
+  height: number;
+}
+
+/** Nesting result holding all placements and sheet info. */
+export interface NestingResult {
+  nestedParts: Placement[];
+  sheet: SheetSpec;
+}
+
+interface PreviewProps {
+  layout: NestingResult;
+}
+
+/**
+ * Renders a simple SVG preview of the nested layout.
+ * Each placement is currently drawn as a 1x1 rectangle at its origin.
+ */
+const NestingPreview: React.FC<PreviewProps> = ({ layout }) => {
+  const { sheet, nestedParts } = layout;
+  // Scale the preview to a fixed width while preserving aspect ratio
+  const previewWidth = 400;
+  const previewHeight = (sheet.height / sheet.width) * previewWidth;
+
+  return (
+    <svg
+      width={previewWidth}
+      height={previewHeight}
+      viewBox={`0 0 ${sheet.width} ${sheet.height}`}
+      style={{ border: '1px solid #ccc' }}
+    >
+      {/* Outline of the sheet */}
+      <rect
+        x={0}
+        y={0}
+        width={sheet.width}
+        height={sheet.height}
+        fill="none"
+        stroke="#000"
+      />
+      {/* Placements rendered as small rectangles */}
+      {nestedParts.map((p, i) => (
+        <rect
+          key={i}
+          x={p.x}
+          y={p.y}
+          width={1}
+          height={1}
+          fill="rgba(0,0,255,0.5)"
+        />
+      ))}
+    </svg>
+  );
+};
+
+export default NestingPreview;


### PR DESCRIPTION
## Summary
- draw nested part placements on an SVG canvas using new `NestingPreview` view
- show preview in nesting form and allow exporting the current layout via `/api/export`

## Testing
- `npm test`
- `./mvnw -q test`


------
https://chatgpt.com/codex/tasks/task_e_68962a06f78083309751f3da7ada5347