### PR TITLE
Configure backend CORS for frontend access

### DIFF
--- a/backend/src/main/java/com/nestingapp/BackendApplication.java
+++ b/backend/src/main/java/com/nestingapp/BackendApplication.java
@@ -2,12 +2,34 @@ package com.nestingapp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @SpringBootApplication
 public class BackendApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BackendApplication.class, args);
-	}
+        public static void main(String[] args) {
+                SpringApplication.run(BackendApplication.class, args);
+        }
+
+        /**
+         * Allow the React development server to access the Spring Boot API.
+         * This global configuration ensures responses include the
+         * `Access-Control-Allow-Origin` header so that the browser does not
+         * block requests from http://localhost:5173 during local development.
+         */
+        @Bean
+        public WebMvcConfigurer corsConfigurer() {
+                return new WebMvcConfigurer() {
+                        @Override
+                        public void addCorsMappings(CorsRegistry registry) {
+                                registry.addMapping("/**")
+                                        .allowedOrigins("http://localhost:5173")
+                                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                                        .allowedHeaders("*");
+                        }
+                };
+        }
 
 }


### PR DESCRIPTION
## Summary
- enable CORS for React dev server by registering a global WebMvcConfigurer
- add explanatory comments for the new CORS setup

## Testing
- `./mvnw test`
- `curl -i -H "Origin: http://localhost:5173" http://localhost:8080/api/status`

------
https://chatgpt.com/codex/tasks/task_e_6897805b37d08330b035fb035d4fe3ed